### PR TITLE
Correction to wget command

### DIFF
--- a/install_boost_1_67
+++ b/install_boost_1_67
@@ -1,4 +1,4 @@
-wget -O boost_1_67_0.tar.gz http://sourceforge.net/projects/boost/files/boost/1.67.0/boost_1_67_0.tar.gz/download
+wget -O boost_1_67_0.tar.gz http://sourceforge.net/projects/boost/files/boost/1.67.0/boost_1_67_0.tar.gz/download --no-check-certificate
 tar xzvf boost_1_67_0.tar.gz
 cd boost_1_67_0/
 


### PR DESCRIPTION
Added --no-check-certificate to wget command. Tested script manually with: Ubuntu 18.04 / v1.4.0-beta-4.
 
Otherwise: ERROR: cannot verify sourceforge.net's certificate ... Unable to locally verify the issuer's authority.