### PR TITLE
Fix V1 wallet.dats can not be opened by V2 clients

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -8,8 +8,8 @@
 // These need to be macros, as version.cpp's and bitcoin-qt.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR       2
 #define CLIENT_VERSION_MINOR       0
-#define CLIENT_VERSION_REVISION    0
-#define CLIENT_VERSION_BUILD       1532034000000
+#define CLIENT_VERSION_REVISION    1
+#define CLIENT_VERSION_BUILD       0
 
 // Converts the parameter X to a string after macro replacement on X has been performed.
 // Don't merge these into one macro!


### PR DESCRIPTION
Fix V1 wallet.dats can not be opened by V2 clients by changing the client version to 2.0.1.0 (client version was negative because of to high build version)