### PR TITLE
Build doc link fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,5 +97,11 @@ boost_1_67_0\.tar\.gz
 Makefile\.am\.user
 /build-src-Desktop_Qt*
 /Prebuild.Spectre.libraries.zip
+
+# CLion/IntelliJ files
+.idea/
+*.iml
+cmake-build-debug/
+
 moc_predefs.h
 /build-tests-Desktop_Qt*

--- a/doc/Windows-build-instructions-README.md
+++ b/doc/Windows-build-instructions-README.md
@@ -25,8 +25,8 @@ Easy (Prebuilt libs)
 
 Since quit many of our users found it hard to compile. Especially on Windows. We are adding an easy way and provided prebuilt package for all the libraries required to compile Spectre wallet. Go ahead and download all the libraries from the following links:
 
-https://github.com/spectrecoin/spectre/releases/download/v2.0.4/Spectre.Prebuild.libraries.zip
-https://github.com/spectrecoin/spectre/releases/download/v2.0.4/Spectre.QT.libraries.zip
+https://github.com/spectrecoin/spectre/releases/download/v2.0.6/Spectre.Prebuild.libraries.zip
+https://github.com/spectrecoin/spectre/releases/download/v2.0.6/Spectre.QT.libraries.zip
 
 Clone Spectre source. You can simply download the “Zip”s from github.
 


### PR DESCRIPTION
Fixed download links on Windows build doc and update .gitignore