### PR TITLE
Qt5.12 activation for Win and Mac

### DIFF
--- a/Docker/Debian/Dockerfile
+++ b/Docker/Debian/Dockerfile
@@ -1,5 +1,5 @@
 ### At first perform source build ###
-FROM spectreproject/spectre-builder-debian:qt5.11 as build
+FROM spectreproject/spectre-builder-debian:1.5 as build
 MAINTAINER HLXEasy <hlxeasy@gmail.com>
 
 # Build parameters

--- a/Docker/Debian/Dockerfile
+++ b/Docker/Debian/Dockerfile
@@ -1,5 +1,5 @@
 ### At first perform source build ###
-FROM spectreproject/spectre-builder-debian:1.3 as build
+FROM spectreproject/spectre-builder-debian:qt5.11 as build
 MAINTAINER HLXEasy <hlxeasy@gmail.com>
 
 # Build parameters

--- a/Docker/Debian/Dockerfile_noUpload
+++ b/Docker/Debian/Dockerfile_noUpload
@@ -1,5 +1,5 @@
 ### At first perform source build ###
-FROM spectreproject/spectre-builder-debian:qt5.11
+FROM spectreproject/spectre-builder-debian:1.5
 MAINTAINER HLXEasy <hlxeasy@gmail.com>
 
 # Build parameters

--- a/Docker/Debian/Dockerfile_noUpload
+++ b/Docker/Debian/Dockerfile_noUpload
@@ -1,5 +1,5 @@
 ### At first perform source build ###
-FROM spectreproject/spectre-builder-debian:1.3
+FROM spectreproject/spectre-builder-debian:qt5.11
 MAINTAINER HLXEasy <hlxeasy@gmail.com>
 
 # Build parameters

--- a/Docker/Fedora/Dockerfile
+++ b/Docker/Fedora/Dockerfile
@@ -1,5 +1,5 @@
 ### At first perform source build ###
-FROM spectreproject/spectre-builder-fedora:1.3 as build
+FROM spectreproject/spectre-builder-fedora:1.5 as build
 MAINTAINER HLXEasy <hlxeasy@gmail.com>
 
 # Build parameters

--- a/Docker/Fedora/Dockerfile
+++ b/Docker/Fedora/Dockerfile
@@ -1,5 +1,5 @@
 ### At first perform source build ###
-FROM spectreproject/spectre-builder-fedora:1.0 as build
+FROM spectreproject/spectre-builder-fedora:1.3 as build
 MAINTAINER HLXEasy <hlxeasy@gmail.com>
 
 # Build parameters

--- a/Docker/Fedora/Dockerfile_noUpload
+++ b/Docker/Fedora/Dockerfile_noUpload
@@ -1,5 +1,5 @@
 ### At first perform source build ###
-FROM spectreproject/spectre-builder-fedora:1.3
+FROM spectreproject/spectre-builder-fedora:1.5
 MAINTAINER HLXEasy <hlxeasy@gmail.com>
 
 # Build parameters

--- a/Docker/Fedora/Dockerfile_noUpload
+++ b/Docker/Fedora/Dockerfile_noUpload
@@ -1,5 +1,5 @@
 ### At first perform source build ###
-FROM spectreproject/spectre-builder-fedora:1.0
+FROM spectreproject/spectre-builder-fedora:1.3
 MAINTAINER HLXEasy <hlxeasy@gmail.com>
 
 # Build parameters

--- a/Docker/RaspberryPi/Dockerfile
+++ b/Docker/RaspberryPi/Dockerfile
@@ -1,5 +1,5 @@
 ### At first perform source build ###
-FROM spectreproject/spectre-builder-raspi:1.4 as build
+FROM spectreproject/spectre-builder-raspi:1.5 as build
 MAINTAINER HLXEasy <hlxeasy@gmail.com>
 
 # Build parameters

--- a/Docker/RaspberryPi/Dockerfile_noUpload
+++ b/Docker/RaspberryPi/Dockerfile_noUpload
@@ -1,5 +1,5 @@
 ### At first perform source build ###
-FROM spectreproject/spectre-builder-raspi:1.4
+FROM spectreproject/spectre-builder-raspi:1.5
 MAINTAINER HLXEasy <hlxeasy@gmail.com>
 
 # Build parameters

--- a/Docker/Ubuntu/Dockerfile
+++ b/Docker/Ubuntu/Dockerfile
@@ -1,5 +1,5 @@
 ### At first perform source build ###
-FROM spectreproject/spectre-builder-ubuntu:1.2 as build
+FROM spectreproject/spectre-builder-ubuntu:1.5 as build
 MAINTAINER HLXEasy <hlxeasy@gmail.com>
 
 # Build parameters

--- a/Docker/Ubuntu/Dockerfile_noUpload
+++ b/Docker/Ubuntu/Dockerfile_noUpload
@@ -1,5 +1,5 @@
 ### At first perform source build ###
-FROM spectreproject/spectre-builder-ubuntu:1.2
+FROM spectreproject/spectre-builder-ubuntu:1.5
 MAINTAINER HLXEasy <hlxeasy@gmail.com>
 
 # Build parameters

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,7 +224,8 @@ pipeline {
                                 label "windows"
                             }
                             environment {
-                                QTDIR = "C:\\Qt\\5.9.6\\msvc2017_64"
+//                                QTDIR = "C:\\Qt\\5.9.6\\msvc2017_64"
+                                QTDIR = "C:\\Qt\\5.11.2\\msvc2017_64"
                             }
                             steps {
                                 script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
         GITHUB_TOKEN = credentials('cdc81429-53c7-4521-81e9-83a7992bca76')
         DEVELOP_TAG = "Build${BUILD_NUMBER}"
         RELEASE_TAG = '2.2.0'
-        BLOCKCHAIN_ARCHIVE_VERSION = "2018-11-22"
+        BLOCKCHAIN_ARCHIVE_VERSION = "2018-12-21"
         GIT_TAG_TO_USE = "${DEVELOP_TAG}"
         GIT_COMMIT_SHORT = sh(
                 script: "printf \$(git rev-parse --short ${GIT_COMMIT})",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,8 +224,7 @@ pipeline {
                                 label "windows"
                             }
                             environment {
-//                                QTDIR = "C:\\Qt\\5.9.6\\msvc2017_64"
-                                QTDIR = "C:\\Qt\\5.11.2\\msvc2017_64"
+                                QTDIR = "${QT_DIR_WIN}"
                             }
                             steps {
                                 script {
@@ -601,8 +600,7 @@ pipeline {
                                 label "windows"
                             }
                             environment {
-//                                QTDIR = "C:\\Qt\\5.9.6\\msvc2017_64"
-                                QTDIR = "C:\\Qt\\5.11.2\\msvc2017_64"
+                                QTDIR = "${QT_DIR_WIN}"
                             }
                             steps {
                                 script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -600,7 +600,8 @@ pipeline {
                                 label "windows"
                             }
                             environment {
-                                QTDIR = "C:\\Qt\\5.9.6\\msvc2017_64"
+//                                QTDIR = "C:\\Qt\\5.9.6\\msvc2017_64"
+                                QTDIR = "C:\\Qt\\5.11.2\\msvc2017_64"
                             }
                             steps {
                                 script {

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -42,7 +42,7 @@ We have implemented a check for DCBs and we have implemented a replay protection
 - Progress indicator for load block index, clear cache and rescanning. Fixes the "disconnected UI" problem after startup.
 - Fix: Rescanning of ATXO (Also fixes [#45](https://github.com/spectrecoin/spectre/issues/45))
 - Fix: Tor was not started for windows if wallet path contained a space
-- Update to QT 5.12 for Windows and MacOS (Fixes Mojave dark theme issues)
+- Update to Qt 5.12 for Windows and MacOS (Fixes Mojave dark theme issues)
 - Automatic Build improvements:
   - All wallets show now their build commit hash in the about dialog and on the main window title. ([#117](https://github.com/spectrecoin/spectre/issues/117))
   - Build from develop branch also have the build number and the commit hash in their archive name.

--- a/scripts/mac-deployqt.sh
+++ b/scripts/mac-deployqt.sh
@@ -64,5 +64,5 @@ done
 
 
 info "Create dmg package:"
-${QT_PATH}/bin/macdeployqt src/bin/Spectrecoin.app -dmg
+${QT_PATH}/bin/macdeployqt src/bin/Spectrecoin.app -dmg -always-overwrite
 mv src/bin/Spectrecoin.dmg Spectrecoin.dmg

--- a/scripts/mac-deployqt.sh
+++ b/scripts/mac-deployqt.sh
@@ -39,7 +39,7 @@ if [ -e src/bin/spectrecoin.dmg ] ; then
 fi
 
 info "Call macdeployqt:"
-${QT_PATH}/bin/macdeployqt src/bin/Spectrecoin.app
+${QT_PATH}/bin/macdeployqt src/bin/Spectrecoin.app -always-overwrite
 
 info "Remove openssl 1.0.0 libs:"
 rm -v src/bin/spectrecoin.app/Contents/Frameworks/libssl.1.0.0.dylib


### PR DESCRIPTION
Also Fedora can use it's latest image now, which contains Qt5.11.1. All the others stay at 5.6.x or 5.7x as there is no stable version 5.11 or higher available at the moment.