### PR TITLE
#280: Fix help cmdline option

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -48,6 +48,7 @@ SPDX-License-Identifier: MIT
 - [#14](https://github.com/aliascash/alias-wallet/issues/14)
   Localization of main wallet
 - Localization of installer and Shell-UI
+- [#280](https://github.com/aliascash/alias-wallet/issues/280) Fixed cmdline option `-help` (`-h`)
 
 ## 4.3.1 (released 2020-12-08)
 - Update to Qt 5.12.10 (Mac)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -231,7 +231,7 @@ bool static Bind(const CService &addr, bool fError = true)
 std::string HelpMessage()
 {
     std::string strUsage = _("Options:") + "\n";
-    strUsage += "  -?                     " + _("This help message") + "\n";
+    strUsage += "  -?|-help               " + _("This help message") + "\n";
     strUsage += "  -conf=<file>           " + _("Specify configuration file (default: alias.conf)") + "\n";
     strUsage += "  -pid=<file>            " + _("Specify pid file (default: alias.pid)") + "\n";
     strUsage += "  -datadir=<dir>         " + _("Specify data directory") + "\n";

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -231,7 +231,7 @@ bool static Bind(const CService &addr, bool fError = true)
 std::string HelpMessage()
 {
     std::string strUsage = _("Options:") + "\n";
-    strUsage += "  -?|-help               " + _("This help message") + "\n";
+    strUsage += "  -?|-h|-help            " + _("This help message") + "\n";
     strUsage += "  -conf=<file>           " + _("Specify configuration file (default: alias.conf)") + "\n";
     strUsage += "  -pid=<file>            " + _("Specify pid file (default: alias.pid)") + "\n";
     strUsage += "  -datadir=<dir>         " + _("Specify data directory") + "\n";

--- a/src/qt/locale/alias_en.ts
+++ b/src/qt/locale/alias_en.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="en" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en">
 <context>
     <name>AboutDialog</name>
     <message>
@@ -1789,7 +1791,10 @@ Please restart the wallet!</translation>
     <message numerus="yes">
         <location filename="../spectregui.cpp" line="562"/>
         <source>%n active connection(s) to Alias network</source>
-        <translation><numerusform>%n active connection to Alias network</numerusform><numerusform>%n active connections to Alias network</numerusform></translation>
+        <translation>
+            <numerusform>%n active connection to Alias network</numerusform>
+            <numerusform>%n active connections to Alias network</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../spectregui.cpp" line="582"/>
@@ -1835,7 +1840,10 @@ Please restart the wallet!</translation>
     <message numerus="yes">
         <location filename="../spectregui.cpp" line="617"/>
         <source>~%n block(s) remaining</source>
-        <translation><numerusform>%n block remaining</numerusform><numerusform>%n blocks remaining</numerusform></translation>
+        <translation>
+            <numerusform>%n block remaining</numerusform>
+            <numerusform>%n blocks remaining</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../spectregui.cpp" line="631"/>
@@ -1850,32 +1858,50 @@ Please restart the wallet!</translation>
     <message numerus="yes">
         <location filename="../spectregui.cpp" line="635"/>
         <source>Imported %n block(s) of transaction history.</source>
-        <translation><numerusform>Imported %n block of transaction history.</numerusform><numerusform>Imported %n blocks of transaction history.</numerusform></translation>
+        <translation>
+            <numerusform>Imported %n block of transaction history.</numerusform>
+            <numerusform>Imported %n blocks of transaction history.</numerusform>
+        </translation>
     </message>
     <message numerus="yes">
         <location filename="../spectregui.cpp" line="635"/>
         <source>Downloaded %n block(s) of transaction history.</source>
-        <translation><numerusform>Downloaded %n block of transaction history.</numerusform><numerusform>Downloaded %n blocks of transaction history.</numerusform></translation>
+        <translation>
+            <numerusform>Downloaded %n block of transaction history.</numerusform>
+            <numerusform>Downloaded %n blocks of transaction history.</numerusform>
+        </translation>
     </message>
     <message numerus="yes">
         <location filename="../spectregui.cpp" line="653"/>
         <source>%n second(s) ago</source>
-        <translation><numerusform>%n second ago</numerusform><numerusform>%n seconds ago</numerusform></translation>
+        <translation>
+            <numerusform>%n second ago</numerusform>
+            <numerusform>%n seconds ago</numerusform>
+        </translation>
     </message>
     <message numerus="yes">
         <location filename="../spectregui.cpp" line="657"/>
         <source>%n minute(s) ago</source>
-        <translation><numerusform>%n minute ago</numerusform><numerusform>%n minutes ago</numerusform></translation>
+        <translation>
+            <numerusform>%n minute ago</numerusform>
+            <numerusform>%n minutes ago</numerusform>
+        </translation>
     </message>
     <message numerus="yes">
         <location filename="../spectregui.cpp" line="661"/>
         <source>%n hour(s) ago</source>
-        <translation><numerusform>%n hour ago</numerusform><numerusform>%n hours ago</numerusform></translation>
+        <translation>
+            <numerusform>%n hour ago</numerusform>
+            <numerusform>%n hours ago</numerusform>
+        </translation>
     </message>
     <message numerus="yes">
         <location filename="../spectregui.cpp" line="664"/>
         <source>%n day(s) ago</source>
-        <translation><numerusform>%n day ago</numerusform><numerusform>%n days ago</numerusform></translation>
+        <translation>
+            <numerusform>%n day ago</numerusform>
+            <numerusform>%n days ago</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../spectregui.cpp" line="671"/>
@@ -2064,7 +2090,10 @@ Note: %2
     <message numerus="yes">
         <location filename="../transactiondesc.cpp" line="44"/>
         <source>Open for %n block(s)</source>
-        <translation><numerusform>Open for %n block</numerusform><numerusform>Open for %n blocks</numerusform></translation>
+        <translation>
+            <numerusform>Open for %n block</numerusform>
+            <numerusform>Open for %n blocks</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../transactiondesc.cpp" line="46"/>
@@ -2114,7 +2143,10 @@ Note: %2
     <message numerus="yes">
         <location filename="../transactiondesc.cpp" line="92"/>
         <source>, broadcast through %n node(s)</source>
-        <translation><numerusform>, broadcast through %n node</numerusform><numerusform>, broadcast through %n nodes</numerusform></translation>
+        <translation>
+            <numerusform>, broadcast through %n node</numerusform>
+            <numerusform>, broadcast through %n nodes</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../transactiondesc.cpp" line="97"/>
@@ -2140,7 +2172,10 @@ Note: %2
     <message numerus="yes">
         <location filename="../transactiondesc.cpp" line="117"/>
         <source>matures in %n more block(s)</source>
-        <translation><numerusform>matures in %n more block</numerusform><numerusform>matures in %n more blocks</numerusform></translation>
+        <translation>
+            <numerusform>matures in %n more block</numerusform>
+            <numerusform>matures in %n more blocks</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../transactiondesc.cpp" line="120"/>
@@ -2293,7 +2328,10 @@ Note: %2
     <message numerus="yes">
         <location filename="../transactiontablemodel.cpp" line="328"/>
         <source>Open for %n more block(s)</source>
-        <translation><numerusform>Open for %n more block</numerusform><numerusform>Open for %n more blocks</numerusform></translation>
+        <translation>
+            <numerusform>Open for %n more block</numerusform>
+            <numerusform>Open for %n more blocks</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../transactiontablemodel.cpp" line="331"/>

--- a/src/qt/spectre.cpp
+++ b/src/qt/spectre.cpp
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
 
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.
-    if (mapArgs.count("-?") || mapArgs.count("--help"))
+    if (mapArgs.count("-?") || mapArgs.count("-help"))
     {
         GUIUtil::HelpMessageBox help;
         help.showOrPrint();

--- a/src/qt/spectre.cpp
+++ b/src/qt/spectre.cpp
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
 
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.
-    if (mapArgs.count("-?") || mapArgs.count("-help"))
+    if (mapArgs.count("-?") || mapArgs.count("-h") || mapArgs.count("-help"))
     {
         GUIUtil::HelpMessageBox help;
         help.showOrPrint();

--- a/src/spectrecoind.cpp
+++ b/src/spectrecoind.cpp
@@ -166,7 +166,7 @@ bool AppInit(int argc, char* argv[])
 
         ReadConfigFile(mapArgs, mapMultiArgs);
 
-        if (mapArgs.count("-?") || mapArgs.count("--help"))
+        if (mapArgs.count("-?") || mapArgs.count("-help"))
         {
             // First part of help message is specific to bitcoind / RPC client
             std::string strUsage = _("Alias version") + " " + FormatFullVersion() + "\n\n" +

--- a/src/spectrecoind.cpp
+++ b/src/spectrecoind.cpp
@@ -166,7 +166,7 @@ bool AppInit(int argc, char* argv[])
 
         ReadConfigFile(mapArgs, mapMultiArgs);
 
-        if (mapArgs.count("-?") || mapArgs.count("-help"))
+        if (mapArgs.count("-?") || mapArgs.count("-h") || mapArgs.count("-help"))
         {
             // First part of help message is specific to bitcoind / RPC client
             std::string strUsage = _("Alias version") + " " + FormatFullVersion() + "\n\n" +


### PR DESCRIPTION
Option `--help` was never working as double-hyphen-prefix is not evaluated properly. As all options already use single hyphen, just use single hyphen also for help output.
Additionally added short form `-h` for convenience on Linux.